### PR TITLE
CLion용 Valgrind/ASan+UBSan 실행 프로필 추가

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,10 @@ ENV TZ=Asia/Seoul LANG=ko_KR.UTF-8 LANGUAGE=ko_KR.UTF-8
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     locales tzdata build-essential sudo gdb vim curl git wget \
     python3 cmake make gcc sudo valgrind telnet net-tools iproute2\
-    && locale-gen ko_KR.UTF-8 && update-locale LANG=ko_KR.UTF-8
+    && locale-gen ko_KR.UTF-8 && update-locale LANG=ko_KR.UTF-8\
+    # CLion 원격 백엔드와 JetBrains 런타임 의존성용 최소 세트
+    apt-get install -y ca-certificates unzip procps \
+    libfreetype6 libxi6 libxext6 libxrender1 libxtst6
 
 RUN useradd -m -s /bin/bash jungle && usermod -aG sudo jungle
 RUN echo "jungle ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jungle

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
                 ],
                 "C_Cpp.default.compilerPath": "/usr/bin/gcc"
             }
+        },
+        "jetbrains": {
+            "backend": "CLion"
         }
     }
 }

--- a/.run/CLion ASan+UBSan.run.xml
+++ b/.run/CLion ASan+UBSan.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CLion ASan+UBSan" type="ShConfigurationType" singleton="false">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/.run/clion-run.sh" />
+    <option name="SCRIPT_OPTIONS" value="asan-ubsan" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/CLion Valgrind.run.xml
+++ b/.run/CLion Valgrind.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CLion Valgrind" type="ShConfigurationType" singleton="false">
+    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/.run/clion-run.sh" />
+    <option name="SCRIPT_OPTIONS" value="valgrind-run" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/clion-run.sh
+++ b/.run/clion-run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../malloc-lab"
+exec make "$@"

--- a/malloc-lab/Makefile
+++ b/malloc-lab/Makefile
@@ -11,6 +11,8 @@ CFLAGS = -Wall -O2 -g
 
 OBJS = mdriver.o mm.o memlib.o fsecs.o fcyc.o clock.o ftimer.o
 
+.PHONY: asan-ubsan valgrind-run
+
 mdriver: $(OBJS)
 	$(CC) $(CFLAGS) -o mdriver $(OBJS)
 
@@ -25,7 +27,16 @@ clock.o: clock.c clock.h
 handin:
 	cp mm.c $(HANDINDIR)/$(TEAM)-$(VERSION)-mm.c
 
+asan-ubsan:
+	$(MAKE) clean
+	$(MAKE) CFLAGS='-Wall -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer'
+	UBSAN_OPTIONS=print_stacktrace=1 ./mdriver -V -f short1-bal.rep
+
+valgrind-run:
+	$(MAKE) clean
+	$(MAKE) CFLAGS='-Wall -O0 -g'
+	valgrind --leak-check=full --track-origins=yes ./mdriver -V -f short1-bal.rep
+
 clean:
 	rm -f *~ *.o mdriver
-
 


### PR DESCRIPTION
## 배경
이 저장소는 devcontainer 기반으로 VS Code 사용 흐름은 이미 갖추고 있었지만, CLion에서 같은 컨테이너 환경을 기준으로 메모리 진단 실행을 바로 선택할 수 있는 공유 실행 프로필은 없었습니다.

이번 변경은 VS Code 설정이나 프로젝트 구조를 CMake 기반으로 확장하지 않고, 현재 Makefile 기반 흐름을 유지한 채 CLion에서 바로 재사용 가능한 최소 실행 프로필만 추가하는 것을 목표로 합니다.

## 무엇을 바꿨는가
- `malloc-lab/Makefile`에 `asan-ubsan`, `valgrind-run` 타깃을 추가했습니다.
- `.run/clion-run.sh`를 추가해서 CLion 공유 실행 설정이 단순히 `make <target>`만 호출하도록 만들었습니다.
- `.run/CLion ASan+UBSan.run.xml`을 추가해서 CLion에서 AddressSanitizer + UndefinedBehaviorSanitizer 실행 프로필을 바로 선택할 수 있게 했습니다.
- `.run/CLion Valgrind.run.xml`을 추가해서 CLion에서 Valgrind 실행 프로필을 바로 선택할 수 있게 했습니다.

## 왜 이렇게 구성했는가
- 이 프로젝트는 CMake 프로젝트가 아니라 Makefile 기반이므로, `CMakePresets.json`이나 별도 `CMakeLists.txt`를 추가하는 방향은 변경 범위가 커집니다.
- CLion에서 필요한 것은 빌드 시스템 전환이 아니라 devcontainer 안에서 실행할 수 있는 공유 Run Configuration이므로, `.run` + Make 타깃 조합이 가장 작고 직접적입니다.
- 래퍼 스크립트는 하나만 두고 실제 동작은 Makefile 타깃 이름으로 분기하게 해서, 이후 다른 프로젝트에서도 타깃 이름만 맞추면 같은 패턴을 쉽게 복사할 수 있게 했습니다.

## 사용 방법
1. devcontainer 환경에서 프로젝트를 엽니다.
2. CLion에서 Run/Debug Configuration 목록을 확인합니다.
3. `CLion ASan+UBSan` 또는 `CLion Valgrind`를 선택해 실행합니다.

## 다른 프로젝트에 참고할 때 포인트
- 실행 바이너리가 다르면 Makefile 안의 실행 명령만 바꾸면 됩니다.
- 테스트 입력이 다르면 `./mdriver -V -f short1-bal.rep` 부분만 프로젝트에 맞게 바꾸면 됩니다.
- CLion 쪽 공유 설정은 `.run/*.run.xml`에서 `SCRIPT_OPTIONS`로 넘기는 Make 타깃 이름만 맞추면 그대로 재사용할 수 있습니다.
- devcontainer를 기준으로 한다면 Valgrind 설치 여부와 툴체인 차이도 컨테이너 안에서 통일할 수 있습니다.

## 검증
- `./.run/clion-run.sh asan-ubsan` 실행 기준으로 `short1-bal.rep` 테스트가 정상 완료되는 것까지 확인했습니다.
- Valgrind 프로필은 devcontainer 내부에 `valgrind`가 설치되어 있다는 현재 저장소 전제를 기준으로 연결했습니다.

## 범위 밖
- VS Code 설정 변경
- CMake 전환
- CLion 전용 디버거/프로파일러 세부 옵션 세팅

이 PR은 CLion에서 devcontainer 기반 메모리 진단 실행을 바로 쓸 수 있게 만드는 최소 공유 설정 추가에 집중합니다.